### PR TITLE
fixed broken line that hinders compliation

### DIFF
--- a/http.go
+++ b/http.go
@@ -87,8 +87,6 @@ func (server *httpServer) handleKeyPost(w http.ResponseWriter, r *http.Request) 
 		server.logger.Error().Err(err).Msg("")
 	}
 
-	server.node.raftNode.
-
 	applyFuture := server.node.raftNode.Apply(eventBytes, 5*time.Second)
 	if err := applyFuture.Error(); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Appears that there was accidentally a broken line left in some of the HTTP handling. Everything functions correctly without the statement, and has been tested. Code does not build without the removal of this line.